### PR TITLE
Update uncrustify to 0.78.1 & Update checksum

### DIFF
--- a/meta-ros-common/recipes-devtools/uncrustify/uncrustify_0.78.1.bb
+++ b/meta-ros-common/recipes-devtools/uncrustify/uncrustify_0.78.1.bb
@@ -19,12 +19,12 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f \
                     file://tests/cli/config/copyright-header.cfg;md5=4433a6f744a8775490b71430c0c4c57e \
                     file://tests/cli/config/copyright-header.txt;md5=9d650176fa4899e13c8f541109878777 \
                     file://tests/cli/output/copyright-header.cpp;md5=65c3951fdb0755160a989c87569e062c \
-                    file://package.json;md5=b43f590b0d3f887322788d4522c747ad"
+                    file://package.json;md5=dcbffda08426a91939bf2a9f1496e1d2"
 
 SRC_URI = " \
-    git://github.com/uncrustify/uncrustify.git;protocol=https;branch=uncrustify-0.75.x \
+    git://github.com/uncrustify/uncrustify.git;protocol=https;branch=master \
     "
-SRCREV = "639856e61770c785b5b85612e9a431d720fd8e4f"
+SRCREV = "b8c95286f70ef8e0e83bd055a3a7aabb614a0781"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Build failed because of this recipe pointing to a non-existing branch.

Now update uncrustify to 0.78.1.